### PR TITLE
allow less hardcoded configuration of the server and handlers

### DIFF
--- a/conf/pbf2graph.json
+++ b/conf/pbf2graph.json
@@ -15,5 +15,11 @@
     "node_function": "nodes_proc",
     "way_script": "conf/osm2pgsql/edges.lua",
     "way_function": "ways_proc"
+  },
+  "logging": {
+    "tyr": {
+      "type": "std_out",
+      "color": true
+    }
   }
 }

--- a/src/tyr/handler.cc
+++ b/src/tyr/handler.cc
@@ -10,7 +10,7 @@
 namespace valhalla {
 namespace tyr {
 
-Handler::Handler(const boost::python::dict& dict_request) {
+Handler::Handler(const std::string& config, const boost::python::dict& dict_request):config_(config) {
   //we require locations
   if(!dict_request.has_key("loc"))
     throw std::runtime_error("required parameter `loc' was not provided");

--- a/src/tyr/locate_handler.cc
+++ b/src/tyr/locate_handler.cc
@@ -3,7 +3,7 @@
 namespace valhalla {
 namespace tyr {
 
-LocateHandler::LocateHandler(const boost::python::dict& dict_request) : Handler(dict_request) {
+LocateHandler::LocateHandler(const std::string& config, const boost::python::dict& dict_request) : Handler(config, dict_request) {
 
 }
 

--- a/src/tyr/nearest_handler.cc
+++ b/src/tyr/nearest_handler.cc
@@ -3,7 +3,7 @@
 namespace valhalla {
 namespace tyr {
 
-NearestHandler::NearestHandler(const boost::python::dict& dict_request) : Handler(dict_request) {
+NearestHandler::NearestHandler(const std::string& config, const boost::python::dict& dict_request) : Handler(config, dict_request) {
 
 }
 

--- a/src/tyr/route_handler.cc
+++ b/src/tyr/route_handler.cc
@@ -214,7 +214,7 @@ void serialize(const valhalla::odin::TripPath& trip_path,
 namespace valhalla {
 namespace tyr {
 
-RouteHandler::RouteHandler(const boost::python::dict& dict_request) : Handler(dict_request) {
+RouteHandler::RouteHandler(const std::string& config, const boost::python::dict& dict_request) : Handler(config, dict_request) {
   //parse out the type of route
   if(!dict_request.has_key("costing_method"))
     throw std::runtime_error("No edge/node costing method provided");
@@ -228,8 +228,7 @@ RouteHandler::RouteHandler(const boost::python::dict& dict_request) : Handler(di
   cost_ = factory.Create(costing_method);
   //get the config for the graph reader
   boost::property_tree::ptree pt;
-  std::string config_file = boost::python::extract<std::string>(boost::python::str(dict_request["config"]));
-  boost::property_tree::read_json(config_file, pt);
+  boost::property_tree::read_json(config, pt);
   reader_.reset(new valhalla::baldr::GraphReader(pt));
 
   //TODO: we get other info such as: z (zoom level), output (format), instructions (text)

--- a/src/tyr/service_handlers_python.cc
+++ b/src/tyr/service_handlers_python.cc
@@ -2,29 +2,86 @@
 #include "tyr/route_handler.h"
 #include "tyr/locate_handler.h"
 #include "tyr/nearest_handler.h"
+#include <valhalla/midgard/logging.h>
 
+#include <string>
 #include <boost/python.hpp>
+#include <boost/python/str.hpp>
+#include <boost/python/dict.hpp>
+#include <boost/python/extract.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/optional.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
+namespace {
+
+  //statically set the config file and configure logging, throw if you never configured
+  //configuring multiple times is wasteful/ineffectual but not harmful
+  std::string configure(const boost::optional<std::string>& config = boost::none) {
+    //if it turned out no one ever configured us we throw
+    static boost::optional<std::string> cached(config);
+    if(!cached)
+      throw std::runtime_error("The service was not configured");
+
+    try {
+      //parse the config
+      boost::property_tree::ptree pt;
+      boost::property_tree::read_json(*cached, pt);
+
+      //configure logging
+      boost::optional<boost::property_tree::ptree&> logging_subtree = pt.get_child_optional("logging.tyr");
+      if(logging_subtree) {
+        auto logging_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string> >(logging_subtree.get());
+        valhalla::midgard::logging::Configure(logging_config);
+      }
+    }
+    catch(...) {
+      throw std::runtime_error("Failed to load config from: " + *cached);
+    }
+
+    return *cached;
+  }
+  void py_configure(const boost::python::str& config) {
+    std::string config_file = boost::python::extract<std::string>(config);
+    configure(config_file);
+  }
+
+  //use to construct handlers without having to pass the config everytime
+  template <class handler_t>
+  boost::shared_ptr<handler_t> init(const boost::python::dict& d) {
+    //slip in the config file
+    std::string config = configure();
+    //construct the object
+    return boost::make_shared<handler_t>(config, d);
+  }
+
+}
 
 BOOST_PYTHON_MODULE(tyr_service) {
 
+  boost::python::def("Configure", py_configure);
+
   boost::python::class_<valhalla::tyr::LocateHandler,
       boost::shared_ptr<valhalla::tyr::LocateHandler>,
-      boost::noncopyable>("LocateHandler", boost::python::init<const boost::python::dict&>())
+      boost::noncopyable>("LocateHandler", boost::python::no_init)
+    .def("__init__", boost::python::make_constructor(init<valhalla::tyr::LocateHandler>))
     .def("Action", &valhalla::tyr::LocateHandler::Action)
   ;
 
   boost::python::class_<valhalla::tyr::NearestHandler,
       boost::shared_ptr<valhalla::tyr::NearestHandler>,
-      boost::noncopyable>("NearestHandler", boost::python::init<const boost::python::dict&>())
+      boost::noncopyable>("NearestHandler", boost::python::no_init)
+    .def("__init__", boost::python::make_constructor(init<valhalla::tyr::NearestHandler>))
     .def("Action", &valhalla::tyr::NearestHandler::Action)
   ;
 
   boost::python::class_<valhalla::tyr::RouteHandler,
       boost::shared_ptr<valhalla::tyr::RouteHandler>,
-      boost::noncopyable>("RouteHandler", boost::python::init<const boost::python::dict&>())
+      boost::noncopyable>("RouteHandler", boost::python::no_init)
+    .def("__init__", boost::python::make_constructor(init<valhalla::tyr::RouteHandler>))
     .def("Action", &valhalla::tyr::RouteHandler::Action)
   ;
 

--- a/test/handlers.cc
+++ b/test/handlers.cc
@@ -52,7 +52,7 @@ void write_tiles(const std::string& config_file) {
 }
 
 boost::python::dict make_request(const std::string& loc1, const std::string& loc2,
-  const std::string& request_type, const std::string& config_file) {
+  const std::string& request_type) {
   //the dict should look something like this:
   /*{
       'loc': ['40.657912,-73.914450', '40.040501,-76.306271'],
@@ -74,7 +74,6 @@ boost::python::dict make_request(const std::string& loc1, const std::string& loc
   request["output"] = output;
   bp::list z; z.append("17");
   request["z"] = z;
-  request["config"] = config_file.c_str();
   bp::list instructions; instructions.append("true");
   request["instructions"] = instructions;
   return request;
@@ -89,10 +88,10 @@ void TestRouteHanlder() {
 
   //make the input
   boost::python::dict dict =
-    make_request("47.139815, 9.525708", "47.167321, 9.509609", "auto", "test/test_config");
+    make_request("47.139815, 9.525708", "47.167321, 9.509609", "auto");
 
   //run the route
-  valhalla::tyr::RouteHandler handler(dict);
+  valhalla::tyr::RouteHandler handler("test/test_config", dict);
   LOG_DEBUG(handler.Action());
 }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -17,7 +17,7 @@ void suite::test(const string& test_name, test_function function) {
   cout << setw(32) << test_name << flush;
   try {
     //run the test
-    test_function();
+    function();
     //it didnt throw
     cout << "  [PASS]" << endl;
   }//it threw so log the issue

--- a/valhalla/tyr/handler.h
+++ b/valhalla/tyr/handler.h
@@ -14,10 +14,11 @@ class Handler {
   /**
    * Parses json request data to be used as options for the action
    *
-   * @param dict  the request data
+   * @param config   where the config file resides
+   * @param dict     the request data
    * @return a handler object ready to act
    */
-  Handler(const boost::python::dict& dict_request);
+  Handler(const std::string& config, const boost::python::dict& dict_request);
 
   /**
    * Don't expose the default constructor
@@ -36,6 +37,7 @@ class Handler {
 
  protected:
 
+  std::string config_;
   std::vector<baldr::Location> locations_;
   boost::optional<std::string> jsonp_;
 

--- a/valhalla/tyr/locate_handler.h
+++ b/valhalla/tyr/locate_handler.h
@@ -11,10 +11,11 @@ class LocateHandler : public Handler {
   /**
    * Parses json request data to be used as options for the action
    *
-   * @param dict  the request data
+   * @param config   where the config file resides
+   * @param dict     the request data
    * @return a handler object ready to act
    */
-  LocateHandler(const boost::python::dict& dict_request);
+  LocateHandler(const std::string& config, const boost::python::dict& dict_request);
 
   /**
    * Don't expose the default constructor

--- a/valhalla/tyr/nearest_handler.h
+++ b/valhalla/tyr/nearest_handler.h
@@ -11,10 +11,11 @@ class NearestHandler : public Handler {
   /**
    * Parses json request data to be used as options for the action
    *
-   * @param dict  the request data
+   * @param config   where the config file resides
+   * @param dict     the request data
    * @return a handler object ready to act
    */
-  NearestHandler(const boost::python::dict& dict_request);
+  NearestHandler(const std::string& config, const boost::python::dict& dict_request);
 
   /**
    * Don't expose the default constructor

--- a/valhalla/tyr/route_handler.h
+++ b/valhalla/tyr/route_handler.h
@@ -15,10 +15,11 @@ class RouteHandler : public Handler {
   /**
    * Parses json request data to be used as options for the action
    *
-   * @param dict  the request data
+   * @param config   where the config file resides
+   * @param dict     the request data
    * @return a handler object ready to act
    */
-  RouteHandler(const boost::python::dict& dict_request);
+  RouteHandler(const std::string& config, const boost::python::dict& dict_request);
 
   /**
    * Don't expose the default constructor


### PR DESCRIPTION
again this is all to make chef easier for us in terms of configuration. basically it lets us pass the config in once at startup to the service and again use the same file that all the other binaries use