### PR TITLE
json to ptree for internal request formatting

### DIFF
--- a/conf/valhalla.json
+++ b/conf/valhalla.json
@@ -35,5 +35,24 @@
       "type": "std_out",
       "color": true
     }
+  },
+  "costing": {
+    "auto": {
+      "maneuver_penalty": 5.0,
+      "gate_cost": 30.0,
+      "toll_booth_cost": 15.0,
+      "toll_booth_penalty": 0.0
+    },
+    "auto_shorter": {
+    },
+    "pedestrian": {
+      "walking_speed": 5.1,
+      "walkway_factor": 0.9,
+      "alley_factor": 2.0,
+      "driveway_factor": 2.0,
+      "step_penalty": 30.0
+    },
+    "bicycle": {
+    }
   }
 }

--- a/py/tyr_simple_server.py
+++ b/py/tyr_simple_server.py
@@ -61,8 +61,8 @@ class TyrHandler(BaseHTTPRequestHandler):
     if params.has_key('costing_method') == False:
       raise Exception('Try a valid costing_method: ' + str(methods))
     #do the action
-    #just send the dict over to c++ and use it directly
-    result = action(params).Action()
+    #just send the json over to c++ and parse it there
+    result = action(json.dumps(params, separators=(',', ':'))).Action()
     #hand it back
     return result, jsonp is not None 
 

--- a/py/tyr_simple_server.py
+++ b/py/tyr_simple_server.py
@@ -20,7 +20,6 @@ http://localhost:8002/nearest?loc=40.657912,-73.914450
 #mapping actions to internal methods to call with the input
 #TODO: these will be methods to boost python bindings into the tyr library
 actions = {'locate': tyr_service.LocateHandler, 'nearest': tyr_service.NearestHandler, 'viaroute': tyr_service.RouteHandler, 'route': tyr_service.CustomRouteHandler}
-methods = ['auto', 'pedestrian', 'bicycle']
 
 #enable threaded server
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
@@ -58,8 +57,6 @@ class TyrHandler(BaseHTTPRequestHandler):
       params = json.loads(params['json'])
       if jsonp is not None:
         params['jsonp'] = jsonp
-    if params.has_key('costing_method') == False:
-      raise Exception('Try a valid costing_method: ' + str(methods))
     #do the action
     #just send the json over to c++ and parse it there
     result = action(json.dumps(params, separators=(',', ':'))).Action()

--- a/src/tyr/custom_route_handler.cc
+++ b/src/tyr/custom_route_handler.cc
@@ -213,25 +213,27 @@ void serialize(const valhalla::odin::TripPath& trip_path,
 namespace valhalla {
 namespace tyr {
 
-CustomRouteHandler::CustomRouteHandler(const std::string& config, const boost::python::dict& dict_request) : Handler(config, dict_request) {
+CustomRouteHandler::CustomRouteHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request) : Handler(config, request) {
   //parse out the type of route
-  if(!dict_request.has_key("costing_method"))
+  std::string costing_method;
+  try {
+    costing_method = request.get<std::string>("costing_method");
+  }
+  catch(...) {
     throw std::runtime_error("No edge/node costing method provided");
+  }
+
   //register edge/node costing methods
   valhalla::thor::CostFactory<valhalla::thor::DynamicCost> factory;
   factory.Register("auto", valhalla::thor::CreateAutoCost);
   factory.Register("bicycle", valhalla::thor::CreateBicycleCost);
   factory.Register("pedestrian", valhalla::thor::CreatePedestrianCost);
 
-  boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config, pt);
-
   //get the costing method
-  std::string costing_method = boost::python::extract<std::string>(boost::python::str(dict_request["costing_method"]));
-  cost_ = factory.Create(costing_method, pt.get_child("thor"));
+  cost_ = factory.Create(costing_method, config.get_child("thor"));
 
   //get the config for the graph reader
-  reader_.reset(new valhalla::baldr::GraphReader(pt.get_child("mjolnir.hierarchy")));
+  reader_.reset(new valhalla::baldr::GraphReader(config.get_child("mjolnir.hierarchy")));
 
   //TODO: we get other info such as: z (zoom level), output (format), instructions (text)
 }

--- a/src/tyr/custom_route_handler.cc
+++ b/src/tyr/custom_route_handler.cc
@@ -215,22 +215,25 @@ namespace tyr {
 
 CustomRouteHandler::CustomRouteHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request) : Handler(config, request) {
   //parse out the type of route
-  std::string costing_method;
+  std::string costing;
   try {
-    costing_method = request.get<std::string>("costing_method");
+    costing = request.get<std::string>("costing");
   }
   catch(...) {
-    throw std::runtime_error("No edge/node costing method provided");
+    throw std::runtime_error("No edge/node costing provided");
   }
 
   //register edge/node costing methods
   valhalla::thor::CostFactory<valhalla::thor::DynamicCost> factory;
   factory.Register("auto", valhalla::thor::CreateAutoCost);
+  factory.Register("auto_shorter", valhalla::thor::CreateAutoShorterCost);
   factory.Register("bicycle", valhalla::thor::CreateBicycleCost);
   factory.Register("pedestrian", valhalla::thor::CreatePedestrianCost);
 
+  //TODO: overwrite anything in config.costing with anything in request.costing
+
   //get the costing method
-  cost_ = factory.Create(costing_method, config.get_child("thor"));
+  cost_ = factory.Create(costing, config.get_child("costing." + costing));
 
   //get the config for the graph reader
   reader_.reset(new valhalla::baldr::GraphReader(config.get_child("mjolnir.hierarchy")));

--- a/src/tyr/locate_handler.cc
+++ b/src/tyr/locate_handler.cc
@@ -3,7 +3,7 @@
 namespace valhalla {
 namespace tyr {
 
-LocateHandler::LocateHandler(const std::string& config, const boost::python::dict& dict_request) : Handler(config, dict_request) {
+LocateHandler::LocateHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request) : Handler(config, request) {
 
 }
 

--- a/src/tyr/nearest_handler.cc
+++ b/src/tyr/nearest_handler.cc
@@ -3,7 +3,7 @@
 namespace valhalla {
 namespace tyr {
 
-NearestHandler::NearestHandler(const std::string& config, const boost::python::dict& dict_request) : Handler(config, dict_request) {
+NearestHandler::NearestHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request) : Handler(config, request) {
 
 }
 

--- a/src/tyr/route_handler.cc
+++ b/src/tyr/route_handler.cc
@@ -226,22 +226,25 @@ namespace tyr {
 
 RouteHandler::RouteHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request) : Handler(config, request) {
   //parse out the type of route
-  std::string costing_method;
+  std::string costing;
   try {
-    costing_method = request.get<std::string>("costing_method");
+    costing = request.get<std::string>("costing");
   }
   catch(...) {
-    throw std::runtime_error("No edge/node costing method provided");
+    throw std::runtime_error("No edge/node costing provided");
   }
 
   //register edge/node costing methods
   valhalla::thor::CostFactory<valhalla::thor::DynamicCost> factory;
   factory.Register("auto", valhalla::thor::CreateAutoCost);
+  factory.Register("auto_shorter", valhalla::thor::CreateAutoShorterCost);
   factory.Register("bicycle", valhalla::thor::CreateBicycleCost);
   factory.Register("pedestrian", valhalla::thor::CreatePedestrianCost);
 
+  //TODO: overwrite anything in config.costing with anything in request.costing
+
   //get the costing method
-  cost_ = factory.Create(costing_method, config.get_child("thor"));
+  cost_ = factory.Create(costing, config.get_child("costing." + costing));
 
   //get the config for the graph reader
   reader_.reset(new valhalla::baldr::GraphReader(config.get_child("mjolnir.hierarchy")));

--- a/src/tyr/route_handler.cc
+++ b/src/tyr/route_handler.cc
@@ -224,25 +224,27 @@ void serialize(const valhalla::odin::TripPath& trip_path,
 namespace valhalla {
 namespace tyr {
 
-RouteHandler::RouteHandler(const std::string& config, const boost::python::dict& dict_request) : Handler(config, dict_request) {
+RouteHandler::RouteHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request) : Handler(config, request) {
   //parse out the type of route
-  if(!dict_request.has_key("costing_method"))
+  std::string costing_method;
+  try {
+    costing_method = request.get<std::string>("costing_method");
+  }
+  catch(...) {
     throw std::runtime_error("No edge/node costing method provided");
+  }
+
   //register edge/node costing methods
   valhalla::thor::CostFactory<valhalla::thor::DynamicCost> factory;
   factory.Register("auto", valhalla::thor::CreateAutoCost);
   factory.Register("bicycle", valhalla::thor::CreateBicycleCost);
   factory.Register("pedestrian", valhalla::thor::CreatePedestrianCost);
 
-  boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config, pt);
-
   //get the costing method
-  std::string costing_method = boost::python::extract<std::string>(boost::python::str(dict_request["costing_method"]));
-  cost_ = factory.Create(costing_method, pt.get_child("thor"));
+  cost_ = factory.Create(costing_method, config.get_child("thor"));
 
   //get the config for the graph reader
-  reader_.reset(new valhalla::baldr::GraphReader(pt.get_child("mjolnir.hierarchy")));
+  reader_.reset(new valhalla::baldr::GraphReader(config.get_child("mjolnir.hierarchy")));
 
   //TODO: we get other info such as: z (zoom level), output (format), instructions (text)
 }

--- a/src/tyr/service_handlers_python.cc
+++ b/src/tyr/service_handlers_python.cc
@@ -6,6 +6,7 @@
 #include <valhalla/midgard/logging.h>
 
 #include <string>
+#include <sstream>
 #include <boost/python.hpp>
 #include <boost/python/str.hpp>
 #include <boost/python/dict.hpp>
@@ -21,42 +22,49 @@ namespace {
 
   //statically set the config file and configure logging, throw if you never configured
   //configuring multiple times is wasteful/ineffectual but not harmful
-  std::string configure(const boost::optional<std::string>& config = boost::none) {
-    //if it turned out no one ever configured us we throw
-    static boost::optional<std::string> cached(config);
-    if(!cached)
-      throw std::runtime_error("The service was not configured");
+  boost::property_tree::ptree configure(const boost::optional<std::string>& config = boost::none) {
+    static boost::optional<boost::property_tree::ptree> pt;
 
-    try {
-      //parse the config
-      boost::property_tree::ptree pt;
-      boost::property_tree::read_json(*cached, pt);
+    //if we haven't already loaded one
+    if(config && !pt) {
+      try {
+        //parse the config
+        boost::property_tree::ptree temp_pt;
+        boost::property_tree::read_json(config.get(), temp_pt);
+        pt = temp_pt;
 
-      //configure logging
-      boost::optional<boost::property_tree::ptree&> logging_subtree = pt.get_child_optional("tyr.logging");
-      if(logging_subtree) {
-        auto logging_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string> >(logging_subtree.get());
-        valhalla::midgard::logging::Configure(logging_config);
+        //configure logging
+        boost::optional<boost::property_tree::ptree&> logging_subtree = pt->get_child_optional("tyr.logging");
+        if(logging_subtree) {
+          auto logging_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string> >(logging_subtree.get());
+          valhalla::midgard::logging::Configure(logging_config);
+        }
+      }
+      catch(...) {
+        throw std::runtime_error("Failed to load config from: " + config.get());
       }
     }
-    catch(...) {
-      throw std::runtime_error("Failed to load config from: " + *cached);
-    }
 
-    return *cached;
+    //if it turned out no one ever configured us we throw
+    if(!pt)
+      throw std::runtime_error("The service was not configured");
+    return *pt;
   }
-  void py_configure(const boost::python::str& config) {
-    std::string config_file = boost::python::extract<std::string>(config);
+  void py_configure(const std::string& config_file) {
     configure(config_file);
   }
 
   //use to construct handlers without having to pass the config everytime
   template <class handler_t>
-  boost::shared_ptr<handler_t> init(const boost::python::dict& d) {
+  boost::shared_ptr<handler_t> init(const std::string& request) {
     //slip in the config file
-    std::string config = configure();
+    auto config = configure();
+    //parse the request json into a ptree
+    std::stringstream stream; stream << request;
+    boost::property_tree::ptree pt;
+    boost::property_tree::read_json(stream, pt);
     //construct the object
-    return boost::make_shared<handler_t>(config, d);
+    return boost::make_shared<handler_t>(config, pt);
   }
 
 }

--- a/test/handlers.cc
+++ b/test/handlers.cc
@@ -21,37 +21,85 @@
 namespace {
 
 void write_config(const std::string& filename) {
+  using namespace valhalla::tyr;
+
   std::ofstream file;
   try {
-  file.open(filename, std::ios_base::trunc);
-  file << "{ \
-      \"thor\": {}, \
-      \"mjolnir\": { \
-        \"input\": { \
-          \"type\": \"protocolbuffer\" \
-        }, \
-        \"hierarchy\": { \
-          \"tile_dir\": \"test/tiles\", \
-          \"levels\": [ \
-            {\"name\": \"local\", \"level\": 2, \"size\": 0.25}, \
-            {\"name\": \"arterial\", \"level\": 1, \"size\": 1, \"importance_cutoff\": \"Tertiary\"}, \
-            {\"name\": \"highway\", \"level\": 0, \"size\": 4, \"importance_cutoff\": \"Trunk\"} \
-          ] \
-        }, \
-        \"tagtransform\": { \
-          \"node_script\": \"test/lua/vertices.lua\", \
-          \"node_function\": \"nodes_proc\", \
-          \"way_script\": \"test/lua/edges.lua\", \
-          \"way_function\": \"ways_proc\", \
-          \"relation_script\": \"test/lua/relations.lua\", \
-          \"relation_function\": \"rels_proc\" \
-        }, \
-        \"admin\": { \
-          \"admin_dir\": \"/data/valhalla\", \
-          \"db_name\": \"admin.sqlite\" \
-        } \
-      } \
-    }";
+    file.open(filename, std::ios_base::trunc);
+    file << *json::map
+      ({
+        {"mjolnir", json::map
+          ({
+            {"input", json::map({{"type", std::string("protocolbuffer")}})},
+            {"hierarchy", json::map
+              ({
+                {"tile_dir", std::string("test/tiles")},
+                {"levels", json::array
+                  ({
+                    json::map({
+                      {"name",std::string("local")},
+                      {"level", static_cast<uint64_t>(2)},
+                      {"size", static_cast<long double>(0.25)}
+                    }),
+                    json::map({
+                      {"name",std::string("arterial")},
+                      {"level", static_cast<uint64_t>(1)},
+                      {"size", static_cast<long double>(1)},
+                      {"importance_cutoff",std::string("Tertiary")}
+                    }),
+                    json::map({
+                      {"name",std::string("highway")},
+                      {"level", static_cast<uint64_t>(0)},
+                      {"size", static_cast<long double>(4)},
+                      {"importance_cutoff",std::string("Trunk")}
+                    })
+                  })
+                }
+              })
+            },
+            {"tagtransform", json::map
+              ({
+                {"node_script", std::string("test/lua/vertices.lua")},
+                {"node_function", std::string("nodes_proc")},
+                {"way_script", std::string("test/lua/edges.lua")},
+                {"way_function", std::string("ways_proc")},
+                {"relation_script", std::string("test/lua/relations.lua")},
+                {"relation_function", std::string("rels_proc")}
+              })
+            },
+            {"admin", json::map
+              ({
+                {"admin_dir", std::string("/data/valhalla")},
+                {"db_name", std::string("admin.sqlite")}
+              })
+            }
+          })
+        },
+        {"thor", json::map({})},
+        {"costing", json::map
+          ({
+            {"auto_shorter", json::map({})},
+            {"bicycle", json::map({})},
+            {"auto", json::map
+              ({
+                {"maneuver_penalty", static_cast<long double>(5.0)},
+                {"gate_cost", static_cast<long double>(30.0)},
+                {"toll_booth_cost", static_cast<long double>(15.0)},
+                {"toll_booth_penalty", static_cast<long double>(0.0)}
+              })
+            },
+            {"pedestrian", json::map
+              ({
+                {"walking_speed", static_cast<long double>(5.1)},
+                {"walkway_factor", static_cast<long double>(0.9)},
+                {"alley_factor", static_cast<long double>(2.0)},
+                {"driveway_factor", static_cast<long double>(2.0)},
+                {"step_penalty", static_cast<long double>(30.0)}
+              })
+            }
+          })
+        }
+      });
   }
   catch(...) {
 

--- a/test/handlers.cc
+++ b/test/handlers.cc
@@ -78,7 +78,7 @@ boost::property_tree::ptree make_request(const std::string& loc1, const std::str
   auto json = json::map
   ({
     {"loc", json::array({ loc1, loc2 })},
-    {"costing_method", request_type},
+    {"costing", request_type},
     {"output", std::string("json")},
     {"z", static_cast<uint64_t>(17)},
     {"instructions", static_cast<bool>(true)},

--- a/valhalla/tyr/custom_route_handler.h
+++ b/valhalla/tyr/custom_route_handler.h
@@ -16,10 +16,10 @@ class CustomRouteHandler : public Handler {
    * Parses json request data to be used as options for the action
    *
    * @param config   where the config file resides
-   * @param dict     the request data
+   * @param json     the request data
    * @return a handler object ready to act
    */
-  CustomRouteHandler(const std::string& config, const boost::python::dict& dict_request);
+  CustomRouteHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& dict_request);
 
   /**
    * Don't expose the default constructor

--- a/valhalla/tyr/handler.h
+++ b/valhalla/tyr/handler.h
@@ -1,7 +1,7 @@
 #ifndef VALHALLA_TYR_HANDLER_H_
 #define VALHALLA_TYR_HANDLER_H_
 
-#include <boost/python/dict.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include <boost/optional.hpp>
 #include <string>
 #include <valhalla/baldr/location.h>
@@ -15,10 +15,10 @@ class Handler {
    * Parses json request data to be used as options for the action
    *
    * @param config   where the config file resides
-   * @param dict     the request data
+   * @param json     the request data
    * @return a handler object ready to act
    */
-  Handler(const std::string& config, const boost::python::dict& dict_request);
+  Handler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request);
 
   /**
    * Don't expose the default constructor
@@ -37,7 +37,7 @@ class Handler {
 
  protected:
 
-  std::string config_;
+  boost::property_tree::ptree config_;
   std::vector<baldr::Location> locations_;
   boost::optional<std::string> jsonp_;
 

--- a/valhalla/tyr/locate_handler.h
+++ b/valhalla/tyr/locate_handler.h
@@ -12,10 +12,10 @@ class LocateHandler : public Handler {
    * Parses json request data to be used as options for the action
    *
    * @param config   where the config file resides
-   * @param dict     the request data
+   * @param json     the request data
    * @return a handler object ready to act
    */
-  LocateHandler(const std::string& config, const boost::python::dict& dict_request);
+  LocateHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& dict_request);
 
   /**
    * Don't expose the default constructor

--- a/valhalla/tyr/nearest_handler.h
+++ b/valhalla/tyr/nearest_handler.h
@@ -12,10 +12,10 @@ class NearestHandler : public Handler {
    * Parses json request data to be used as options for the action
    *
    * @param config   where the config file resides
-   * @param dict     the request data
+   * @param json     the request data
    * @return a handler object ready to act
    */
-  NearestHandler(const std::string& config, const boost::python::dict& dict_request);
+  NearestHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request);
 
   /**
    * Don't expose the default constructor

--- a/valhalla/tyr/route_handler.h
+++ b/valhalla/tyr/route_handler.h
@@ -16,10 +16,10 @@ class RouteHandler : public Handler {
    * Parses json request data to be used as options for the action
    *
    * @param config   where the config file resides
-   * @param dict     the request data
+   * @param json     the request data
    * @return a handler object ready to act
    */
-  RouteHandler(const std::string& config, const boost::python::dict& dict_request);
+  RouteHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& dict_request);
 
   /**
    * Don't expose the default constructor


### PR DESCRIPTION
we only deal with ptrees now for both configuration and requests. in both cases those are built from json. if json parsing becomes a bottleneck at some point we'll look into other parsers/containers

this should make daves work relatively easy when it comes to using options in the request to override config options. also makes easier the server archtiecture since we'll be passing bytes instead of python objects (stuff i'm working on)