### PR TITLE
Updated for json input locations

### DIFF
--- a/test/handlers.cc
+++ b/test/handlers.cc
@@ -172,8 +172,7 @@ boost::property_tree::ptree make_json_request(float lat1, float lng1,
   ({
     {"locations", locations(loc_list)},
     {"costing", request_type},
-    {"output", std::string("json")},
-    {"z", static_cast<uint64_t>(17)},
+    {"output", std::string("json")}
   });
   std::stringstream stream; stream << *json;
   boost::property_tree::ptree pt;

--- a/valhalla/tyr/handler.h
+++ b/valhalla/tyr/handler.h
@@ -20,10 +20,6 @@ class Handler {
    */
   Handler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request);
 
-  /**
-   * Don't expose the default constructor
-   */
-  Handler() = delete;
 
   /**
    * Destructor
@@ -40,6 +36,7 @@ class Handler {
   std::vector<baldr::Location> locations_;
   boost::optional<std::string> jsonp_;
 
+  Handler() {};
 };
 
 }


### PR DESCRIPTION
Example request:
http://localhost:8002/route?json={"locations":[{"latitude":40.748174,"longitude":-73.984984,"type":"break","heading":200,"name":"Empire State Building","street":"350 5th Avenue","city":"New York","state":"NY","postal_code":"10118-0110","country":"US"},{"latitude":40.749231,"longitude":-73.968703,"type":"break","name":"United Nations Headquarters","street":"405 East 42nd Street","city":"New York","state":"NY","postal_code":"10017-3507","country":"US"}],"costing": "auto","output": "json"}

@dnesbitt61 @gknisely @kevinkreiser 