### PR TITLE
add locate service endpoint for transit stop correlation

### DIFF
--- a/src/tyr/custom_route_handler.cc
+++ b/src/tyr/custom_route_handler.cc
@@ -115,7 +115,7 @@ json::MapPtr summary(const valhalla::odin::TripDirections& trip_directions){
     seconds += static_cast<uint64_t>(maneuver.time());
   }
   route_summary->emplace("time", seconds);
-  route_summary->emplace("length", static_cast<long double>(length));
+  route_summary->emplace("length", json::fp_t{length, 3});
   return route_summary;
 }
 
@@ -130,8 +130,8 @@ json::ArrayPtr locations(const valhalla::odin::TripDirections& trip_directions){
     } else {
       loc->emplace("type", std::string("break"));
     }
-    loc->emplace("latitude", static_cast<long double>(location.ll().lat()));
-    loc->emplace("longitude",static_cast<long double>(location.ll().lng()));
+    loc->emplace("latitude", json::fp_t{location.ll().lat(), 6});
+    loc->emplace("longitude",json::fp_t{location.ll().lng(), 6});
     if (!location.name().empty())
       loc->emplace("name",location.name());
     if (!location.street().empty())
@@ -185,7 +185,7 @@ json::ArrayPtr legs(const valhalla::odin::TripDirections& trip_directions){
     if (street_names->size())
       man->emplace("street_names", street_names);
     man->emplace("time", static_cast<uint64_t>(maneuver.time()));
-    man->emplace("length", static_cast<long double>(maneuver.length()));
+    man->emplace("length", json::fp_t{maneuver.length(), 3});
     man->emplace("begin_shape_index", static_cast<uint64_t>(maneuver.begin_shape_index()));
     man->emplace("end_shape_index", static_cast<uint64_t>(maneuver.end_shape_index()));
 
@@ -205,7 +205,7 @@ json::ArrayPtr legs(const valhalla::odin::TripDirections& trip_directions){
   }
   leg->emplace("maneuvers", maneuvers);
   summary->emplace("time", seconds);
-  summary->emplace("length", static_cast<long double>(length));
+  summary->emplace("length", json::fp_t{length, 3});
   leg->emplace("summary",summary);
   leg->emplace("shape", trip_directions.shape());
 

--- a/src/tyr/custom_route_handler.cc
+++ b/src/tyr/custom_route_handler.cc
@@ -241,7 +241,9 @@ namespace valhalla {
 namespace tyr {
 
 CustomRouteHandler::CustomRouteHandler(const boost::property_tree::ptree& config,
-                                       const boost::property_tree::ptree& request) {
+                                       const boost::property_tree::ptree& request)
+  : Handler(config, request) {
+
   try {
     for(const auto& location : request.get_child("locations"))
       locations_.emplace_back(std::move(baldr::Location::FromPtree(location.second)));

--- a/src/tyr/handler.cc
+++ b/src/tyr/handler.cc
@@ -11,17 +11,6 @@ namespace valhalla {
 namespace tyr {
 
 Handler::Handler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request):config_(config) {
-  //we require locations
-  try {
-    for(const auto& loc : request.get_child("loc"))
-      locations_.emplace_back(std::move(baldr::Location::FromCsv(loc.second.get_value<std::string>())));
-    if(locations_.size() < 2)
-      throw;
-  }
-  catch(...) {
-    throw std::runtime_error("insufficiently specified required parameter `loc'");
-  }
-
   //jsonp callback is optional
   auto maybe_jsonp = request.get_child_optional("jsonp");
   std::string jsonp;

--- a/src/tyr/locate_handler.cc
+++ b/src/tyr/locate_handler.cc
@@ -1,9 +1,105 @@
 #include "tyr/locate_handler.h"
+#include "tyr/json.h"
+
+#include <valhalla/baldr/pathlocation.h>
+#include <valhalla/loki/search.h>
+#include <valhalla/sif/costfactory.h>
+#include <valhalla/sif/autocost.h>
+#include <valhalla/sif/bicyclecost.h>
+#include <valhalla/sif/pedestriancost.h>
+
+using namespace valhalla::baldr;
+using namespace valhalla::sif;
+using namespace valhalla::loki;
+using namespace valhalla::tyr;
+
+namespace {
+
+  //TODO: move json header to baldr
+  //TODO: make objects serialize themselves
+
+
+  json::Value serialize_node(const PathLocation& location, GraphReader& reader) {
+    if(location.IsNode()) {
+      auto mp = json::map({});
+      //TODO: get the osm node id
+      //TODO: get the coordinate
+      return mp;
+    }
+    else {
+      return static_cast<nullptr_t>(nullptr);
+    }
+  }
+
+  json::ArrayPtr serialize_edges(const std::vector<PathLocation::PathEdge>& edges, GraphReader& reader) {
+    auto array = json::array({});
+    for(const auto& edge : edges) {
+      //TODO: get the osm way id
+      //TODO: crack open the shape, use the distance to get the coordinate
+    }
+    return array;
+  }
+
+  json::MapPtr serialize(const PathLocation& location, GraphReader& reader) {
+    return json::map({
+      {"node", serialize_node(location, reader)},
+      {"ways", serialize_edges(location.edges(), reader)}
+    });
+  }
+
+}
 
 namespace valhalla {
 namespace tyr {
 
-LocateHandler::LocateHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request) : Handler(config, request) {
+LocateHandler::LocateHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request)
+  : Handler(config, request) {
+
+  //we require locations
+  try {
+    for(const auto& loc : request.get_child("locations"))
+      locations_.emplace_back(std::move(baldr::Location::FromCsv(loc.second.get_value<std::string>())));
+    if(locations_.size() < 2)
+      throw;
+    //TODO: bail if this is too many
+  }
+  catch(...) {
+    throw std::runtime_error("insufficiently specified required parameter `locations'");
+  }
+
+  // Parse out the type of route - this provides the costing method to use
+  std::string costing;
+  try {
+    costing = request.get<std::string>("costing");
+  }
+  catch(...) {
+    throw std::runtime_error("No edge/node costing provided");
+  }
+
+  // Register edge/node costing methods
+  sif::CostFactory<sif::DynamicCost> factory;
+  factory.Register("auto", sif::CreateAutoCost);
+  factory.Register("auto_shorter", sif::CreateAutoShorterCost);
+  factory.Register("bicycle", sif::CreateBicycleCost);
+  factory.Register("pedestrian", sif::CreatePedestrianCost);
+
+  // Get the costing options. Get the base options from the config and the
+  // options for the specified costing method
+  std::string method_options = "costing_options." + costing;
+  boost::property_tree::ptree config_costing = config.get_child(method_options);
+  auto request_costing = request.get_child_optional(method_options);
+  if (request_costing) {
+    // If the request has any options for this costing type, merge the 2
+    // costing options - override any config options that are in the request.
+    // and add any request options not in the config.
+    for (auto r : *request_costing) {
+      config_costing.put_child(r.first, r.second);
+    }
+  }
+  cost_ = factory.Create(costing, config_costing);
+
+  // Get the config for the graph reader
+  reader_.reset(new baldr::GraphReader(config.get_child("mjolnir.hierarchy")));
 
 }
 
@@ -12,7 +108,24 @@ LocateHandler::~LocateHandler() {
 }
 
 std::string LocateHandler::Action() {
-  throw std::runtime_error("Locate is not yet supported");
+  //find the correlate the various locations to the underlying graph
+  std::list<baldr::PathLocation> correlated;
+  for(const auto& location : locations_)
+    correlated.emplace_back(loki::Search(locations_[0], *reader_, cost_->GetFilter()));
+
+  //rip through the correlated ones to create the json array
+  auto json = json::array({});
+  for(const auto& location : correlated)
+    json->emplace_back(serialize(location, *reader_));
+
+  //make some json
+  std::ostringstream stream;
+  if(jsonp_)
+    stream << *jsonp_ << '(';
+  stream << *json;
+  if(jsonp_)
+    stream << ')';
+  return stream.str();
 }
 
 }

--- a/src/tyr/locate_handler.cc
+++ b/src/tyr/locate_handler.cc
@@ -22,12 +22,6 @@ namespace {
   //TODO: move json header to baldr
   //TODO: make objects serialize themselves
 
-  json::ArrayPtr serialize_ll(const PointLL& ll) {
-    return json::array({
-      static_cast<long double>(ll.lat()), static_cast<long double>(ll.lng())
-    });
-  }
-
   json::ArrayPtr serialize_edges(const PathLocation& location, GraphReader& reader) {
     auto array = json::array({});
     std::unordered_multimap<uint64_t, PointLL> ids;
@@ -52,7 +46,8 @@ namespace {
           array->emplace_back(
             json::map({
               {"way_id", edge_info->wayid()},
-              {"correlated_lat_lon", serialize_ll(location.vertex())}
+              {"correlated_lat", json::fp_t{location.latlng_.lat(), 6}},
+              {"correlated_lon", json::fp_t{location.latlng_.lng(), 6}}
             })
           );
         }
@@ -68,14 +63,16 @@ namespace {
   json::MapPtr serialize(const PathLocation& location, GraphReader& reader) {
     return json::map({
       {"ways", serialize_edges(location, reader)},
-      {"input_lat_lon", serialize_ll(location.latlng_)}
+      {"input_lat", json::fp_t{location.latlng_.lat(), 6}},
+      {"input_lon", json::fp_t{location.latlng_.lng(), 6}}
     });
   }
 
   json::MapPtr serialize(const PointLL& ll, const std::string& reason) {
     return json::map({
       {"ways", static_cast<nullptr_t>(nullptr)},
-      {"input_lat_lon", serialize_ll(ll)},
+      {"input_lat", json::fp_t{ll.lat(), 6}},
+      {"input_lon", json::fp_t{ll.lng(), 6}},
       {"reason", reason}
     });
   }

--- a/src/tyr/route_handler.cc
+++ b/src/tyr/route_handler.cc
@@ -228,6 +228,17 @@ namespace tyr {
 
 RouteHandler::RouteHandler(const boost::property_tree::ptree& config, const boost::property_tree::ptree& request)
     : Handler(config, request) {
+  //we require locations
+  try {
+    for(const auto& loc : request.get_child("loc"))
+      locations_.emplace_back(std::move(baldr::Location::FromCsv(loc.second.get_value<std::string>())));
+    if(locations_.size() < 2)
+      throw;
+  }
+  catch(...) {
+    throw std::runtime_error("insufficiently specified required parameter `loc'");
+  }
+
   // Parse out the type of route
   std::string costing;
   try {

--- a/src/tyr/route_handler.cc
+++ b/src/tyr/route_handler.cc
@@ -110,8 +110,7 @@ json::MapPtr route_summary(const valhalla::odin::TripDirections& trip_directions
 json::ArrayPtr via_points(const valhalla::odin::TripPath& trip_path){
   auto via_points = json::array({});
   for(const auto& location : trip_path.location()) {
-    via_points->emplace_back(json::array({static_cast<long double>(location.ll().lat()),
-            static_cast<long double>(location.ll().lng())}));
+    via_points->emplace_back(json::array({json::fp_t{location.ll().lat(),6}, json::fp_t{location.ll().lng(),6}}));
   }
   return via_points;
 }

--- a/test/handlers.cc
+++ b/test/handlers.cc
@@ -44,18 +44,18 @@ void write_config(const std::string& filename) {
                     json::map({
                       {"name",std::string("local")},
                       {"level", static_cast<uint64_t>(2)},
-                      {"size", static_cast<long double>(0.25)}
+                      {"size", json::fp_t{0.25, 2}}
                     }),
                     json::map({
                       {"name",std::string("arterial")},
                       {"level", static_cast<uint64_t>(1)},
-                      {"size", static_cast<long double>(1)},
+                      {"size", json::fp_t{1, 0}},
                       {"importance_cutoff",std::string("Tertiary")}
                     }),
                     json::map({
                       {"name",std::string("highway")},
                       {"level", static_cast<uint64_t>(0)},
-                      {"size", static_cast<long double>(4)},
+                      {"size", json::fp_t{4,0}},
                       {"importance_cutoff",std::string("Trunk")}
                     })
                   })
@@ -87,19 +87,19 @@ void write_config(const std::string& filename) {
             {"bicycle", json::map({})},
             {"auto", json::map
               ({
-                {"maneuver_penalty", static_cast<long double>(5.0)},
-                {"gate_cost", static_cast<long double>(30.0)},
-                {"toll_booth_cost", static_cast<long double>(15.0)},
-                {"toll_booth_penalty", static_cast<long double>(0.0)}
+                {"maneuver_penalty", json::fp_t{5.0, 0}},
+                {"gate_cost", json::fp_t{30.0, 0}},
+                {"toll_booth_cost", json::fp_t{15.0, 0}},
+                {"toll_booth_penalty", json::fp_t{0.0, 0}}
               })
             },
             {"pedestrian", json::map
               ({
-                {"walking_speed", static_cast<long double>(5.1)},
-                {"walkway_factor", static_cast<long double>(0.9)},
-                {"alley_factor", static_cast<long double>(2.0)},
-                {"driveway_factor", static_cast<long double>(2.0)},
-                {"step_penalty", static_cast<long double>(30.0)}
+                {"walking_speed", json::fp_t{5.1, 0}},
+                {"walkway_factor", json::fp_t{0.9, 0}},
+                {"alley_factor", json::fp_t{2.0, 0}},
+                {"driveway_factor", json::fp_t{2.0, 0}},
+                {"step_penalty", json::fp_t{30.0, 0}}
               })
             }
           })
@@ -149,8 +149,8 @@ json::ArrayPtr locations(const std::vector<Location>& loc_list){
 
     auto location = json::map({});
 
-    location->emplace("latitude", static_cast<long double>(loc.latlng_.lat()));
-    location->emplace("longitude",static_cast<long double>(loc.latlng_.lng()));
+    location->emplace("latitude", json::fp_t{loc.latlng_.lat(),6});
+    location->emplace("longitude",json::fp_t{loc.latlng_.lng(),6});
     location->emplace(
         "type",
         (loc.stoptype_ == Location::StopType::THROUGH ?

--- a/test/handlers.cc
+++ b/test/handlers.cc
@@ -1,6 +1,7 @@
 #include "test.h"
 #include "tyr/route_handler.h"
 #include "tyr/custom_route_handler.h"
+#include "tyr/locate_handler.h"
 #include "tyr/json.h"
 
 #include <valhalla/mjolnir/pbfgraphparser.h>
@@ -212,6 +213,19 @@ void TestCustomRouteHandler() {
   LOG_DEBUG(handler.Action());
 }
 
+void TestLocateHandler() {
+  boost::property_tree::ptree config;
+  boost::property_tree::read_json("test/test_config", config);
+
+  //make the input
+  boost::property_tree::ptree request =
+    make_json_request(47.139815, 9.525708, 47.167321, 9.509609, "auto");
+
+  //run the route
+  valhalla::tyr::LocateHandler handler(config, request);
+  LOG_DEBUG(handler.Action());
+}
+
 }
 
 int main() {
@@ -221,9 +235,9 @@ int main() {
 
   suite.test(TEST_CASE(TestCustomRouteHandler));
 
-  //suite.test(TEST_CASE(TestNearestHanlder));
+  //suite.test(TEST_CASE(TestNearestHandler));
 
-  //suite.test(TEST_CASE(TestLocateHanlder));
+  suite.test(TEST_CASE(TestLocateHandler));
 
   return suite.tear_down();
 }

--- a/test/json.cc
+++ b/test/json.cc
@@ -53,12 +53,12 @@ void TestJsonSerialize() {
     {"escaped_string", string("\"\t\r\n\\")}
   });
 
-  string answer = "{\"escaped_string\":\"\\\"\\t\\r\\n\\\\\",\"hint_data\":{\"checksum\":2875622111,\"locations\":[\"_____38_SADaFQQAKwEAABEAAAAAAAAAdgAAAFfLwga4tW0C4P6W-wAARAA\",\"fzhIAP____8wFAQA1AAAAC8BAAAAAAAAAAAAAP____9Uu20CGAiX-wAAAAA\"]},\"route_name\":[\"West 26th Street\",\"Madison Avenue\"],\"found_alternative\":false,\"route_summary\":{\"total_distance\":878,\"total_time\":145,\"start_point\":\"West 26th Street\",\"end_point\":\"West 29th Street\"},\"via_points\":[[40.7444,-73.9904],[40.7458,-73.9881]],\"route_instructions\":[[\"10\",\"West 26th Street\",216,0,52,\"215m\",\"SE\",118],[\"1\",\"East 26th Street\",153,2,29,\"153m\",\"SE\",120],[\"7\",\"Madison Avenue\",237,3,25,\"236m\",\"NE\",29],[\"7\",\"East 29th Street\",155,6,29,\"154m\",\"NW\",299],[\"1\",\"West 29th Street\",118,7,21,\"117m\",\"NW\",299],[\"15\",\"\",0,8,0,\"0m\",\"N\",0]],\"route_geometry\":\"ozyulA~p_clCfc@ywApTar@li@ybBqe@c[ue@e[ue@i[ci@dcB}^rkA\",\"status_message\":\"Found route between points\",\"via_indices\":[0,9],\"status\":0}";
+  string answer = "{\"escaped_string\":\"\\\"\\t\\r\\n\\\\\",\"hint_data\":{\"checksum\":2875622111,\"locations\":[\"_____38_SADaFQQAKwEAABEAAAAAAAAAdgAAAFfLwga4tW0C4P6W-wAARAA\",\"fzhIAP____8wFAQA1AAAAC8BAAAAAAAAAAAAAP____9Uu20CGAiX-wAAAAA\"]},\"route_name\":[\"West 26th Street\",\"Madison Avenue\"],\"found_alternative\":false,\"route_summary\":{\"total_distance\":878,\"total_time\":145,\"start_point\":\"West 26th Street\",\"end_point\":\"West 29th Street\"},\"via_points\":[[40.744377,-73.990433],[40.745811,-73.988075]],\"route_instructions\":[[\"10\",\"West 26th Street\",216,0,52,\"215m\",\"SE\",118],[\"1\",\"East 26th Street\",153,2,29,\"153m\",\"SE\",120],[\"7\",\"Madison Avenue\",237,3,25,\"236m\",\"NE\",29],[\"7\",\"East 29th Street\",155,6,29,\"154m\",\"NW\",299],[\"1\",\"West 29th Street\",118,7,21,\"117m\",\"NW\",299],[\"15\",\"\",0,8,0,\"0m\",\"N\",0]],\"route_geometry\":\"ozyulA~p_clCfc@ywApTar@li@ybBqe@c[ue@e[ue@i[ci@dcB}^rkA\",\"status_message\":\"Found route between points\",\"via_indices\":[0,9],\"status\":0}";
   ostringstream result;
   result << *json;
 
   if(answer != result.str())
-    throw std::runtime_error("Unexpected json: " + result.str());
+    throw std::runtime_error("Expected: " + answer + " But got: " + result.str());
 }
 
 }

--- a/test/json.cc
+++ b/test/json.cc
@@ -33,8 +33,8 @@ void TestJsonSerialize() {
     },
     {"via_points", json::array
       ({
-        json::array({(long double)(40.744377), (long double)(-73.990433)}),
-        json::array({(long double)(40.745811), (long double)(-73.988075)})
+        json::array({json::fp_t{40.744377, 3}, json::fp_t{-73.990433, 3}}),
+        json::array({json::fp_t{40.745811, 3}, json::fp_t{-73.988075, 3}})
       })
     },
     {"route_instructions", json::array
@@ -53,7 +53,7 @@ void TestJsonSerialize() {
     {"escaped_string", string("\"\t\r\n\\")}
   });
 
-  string answer = "{\"escaped_string\":\"\\\"\\t\\r\\n\\\\\",\"hint_data\":{\"checksum\":2875622111,\"locations\":[\"_____38_SADaFQQAKwEAABEAAAAAAAAAdgAAAFfLwga4tW0C4P6W-wAARAA\",\"fzhIAP____8wFAQA1AAAAC8BAAAAAAAAAAAAAP____9Uu20CGAiX-wAAAAA\"]},\"route_name\":[\"West 26th Street\",\"Madison Avenue\"],\"found_alternative\":false,\"route_summary\":{\"total_distance\":878,\"total_time\":145,\"start_point\":\"West 26th Street\",\"end_point\":\"West 29th Street\"},\"via_points\":[[40.744377,-73.990433],[40.745811,-73.988075]],\"route_instructions\":[[\"10\",\"West 26th Street\",216,0,52,\"215m\",\"SE\",118],[\"1\",\"East 26th Street\",153,2,29,\"153m\",\"SE\",120],[\"7\",\"Madison Avenue\",237,3,25,\"236m\",\"NE\",29],[\"7\",\"East 29th Street\",155,6,29,\"154m\",\"NW\",299],[\"1\",\"West 29th Street\",118,7,21,\"117m\",\"NW\",299],[\"15\",\"\",0,8,0,\"0m\",\"N\",0]],\"route_geometry\":\"ozyulA~p_clCfc@ywApTar@li@ybBqe@c[ue@e[ue@i[ci@dcB}^rkA\",\"status_message\":\"Found route between points\",\"via_indices\":[0,9],\"status\":0}";
+  string answer = "{\"escaped_string\":\"\\\"\\t\\r\\n\\\\\",\"hint_data\":{\"checksum\":2875622111,\"locations\":[\"_____38_SADaFQQAKwEAABEAAAAAAAAAdgAAAFfLwga4tW0C4P6W-wAARAA\",\"fzhIAP____8wFAQA1AAAAC8BAAAAAAAAAAAAAP____9Uu20CGAiX-wAAAAA\"]},\"route_name\":[\"West 26th Street\",\"Madison Avenue\"],\"found_alternative\":false,\"route_summary\":{\"total_distance\":878,\"total_time\":145,\"start_point\":\"West 26th Street\",\"end_point\":\"West 29th Street\"},\"via_points\":[[40.744,-73.990],[40.746,-73.988]],\"route_instructions\":[[\"10\",\"West 26th Street\",216,0,52,\"215m\",\"SE\",118],[\"1\",\"East 26th Street\",153,2,29,\"153m\",\"SE\",120],[\"7\",\"Madison Avenue\",237,3,25,\"236m\",\"NE\",29],[\"7\",\"East 29th Street\",155,6,29,\"154m\",\"NW\",299],[\"1\",\"West 29th Street\",118,7,21,\"117m\",\"NW\",299],[\"15\",\"\",0,8,0,\"0m\",\"N\",0]],\"route_geometry\":\"ozyulA~p_clCfc@ywApTar@li@ybBqe@c[ue@e[ue@i[ci@dcB}^rkA\",\"status_message\":\"Found route between points\",\"via_indices\":[0,9],\"status\":0}";
   ostringstream result;
   result << *json;
 

--- a/valhalla/tyr/custom_route_handler.h
+++ b/valhalla/tyr/custom_route_handler.h
@@ -38,6 +38,7 @@ class CustomRouteHandler : public Handler {
   virtual std::string Action();
 
  protected:
+  std::vector<baldr::Location> locations_;
   bool km_units_;
   std::string units_;
   valhalla::sif::cost_ptr_t cost_;

--- a/valhalla/tyr/handler.h
+++ b/valhalla/tyr/handler.h
@@ -33,7 +33,6 @@ class Handler {
 
  protected:
   boost::property_tree::ptree config_;
-  std::vector<baldr::Location> locations_;
   boost::optional<std::string> jsonp_;
 
   Handler() {};

--- a/valhalla/tyr/json.h
+++ b/valhalla/tyr/json.h
@@ -75,7 +75,7 @@ class OstreamVisitor : public boost::static_visitor<std::ostream&>
   }
   std::ostream& operator()(uint64_t value) const { return ostream_ << value; }
   std::ostream& operator()(int64_t value) const { return ostream_ << value; }
-  std::ostream& operator()(long double value) const { return ostream_ << value; }
+  std::ostream& operator()(long double value) const { return ostream_ << std::setprecision(6) << std::fixed << value; }
   std::ostream& operator()(bool value) const { return ostream_ << (value ? "true" : "false"); }
   std::ostream& operator()(nullptr_t value) const { return ostream_ << "null"; }
   std::ostream& operator()(const MapPtr& value) const { return ostream_ << *value; }

--- a/valhalla/tyr/json.h
+++ b/valhalla/tyr/json.h
@@ -21,9 +21,15 @@ class Jmap;
 using MapPtr = std::shared_ptr<Jmap>;
 class Jarray;
 using ArrayPtr = std::shared_ptr<Jarray>;
+struct fp_t {
+  long double value;
+  size_t precision;
+  //and be able to spit out text
+  friend std::ostream& operator<<(std::ostream& stream, const fp_t&);
+};
 
 //a variant of all the possible values to go with keys in json
-using Value = boost::variant<std::string, uint64_t, int64_t, long double, bool, nullptr_t, MapPtr, ArrayPtr>;
+using Value = boost::variant<std::string, uint64_t, int64_t, fp_t, bool, nullptr_t, MapPtr, ArrayPtr>;
 
 //the map value type in json
 class Jmap : public std::unordered_map<std::string, Value> {
@@ -31,7 +37,7 @@ class Jmap : public std::unordered_map<std::string, Value> {
   //just specialize unoredered_map
   using std::unordered_map<std::string, Value>::unordered_map;
   //and be able to spit out text
-  friend std::ostream& operator<<(std::ostream& stream, const Jmap& json);
+  friend std::ostream& operator<<(std::ostream&, const Jmap&);
 };
 
 //the array value type in json
@@ -41,7 +47,7 @@ class Jarray : public std::vector<Value> {
   using std::vector<Value>::vector;
  protected:
   //and be able to spit out text
-  friend std::ostream& operator<<(std::ostream& stream, const Jarray& json);
+  friend std::ostream& operator<<(std::ostream&, const Jarray&);
 };
 
 //how we serialize the different primitives to string
@@ -75,7 +81,7 @@ class OstreamVisitor : public boost::static_visitor<std::ostream&>
   }
   std::ostream& operator()(uint64_t value) const { return ostream_ << value; }
   std::ostream& operator()(int64_t value) const { return ostream_ << value; }
-  std::ostream& operator()(long double value) const { return ostream_ << std::setprecision(6) << std::fixed << value; }
+  std::ostream& operator()(fp_t value) const { return ostream_ << value; }
   std::ostream& operator()(bool value) const { return ostream_ << (value ? "true" : "false"); }
   std::ostream& operator()(nullptr_t value) const { return ostream_ << "null"; }
   std::ostream& operator()(const MapPtr& value) const { return ostream_ << *value; }
@@ -83,6 +89,11 @@ class OstreamVisitor : public boost::static_visitor<std::ostream&>
  private:
   std::ostream& ostream_;
 };
+
+inline std::ostream& operator<<(std::ostream& stream, const fp_t& fp){
+  stream << std::setprecision(fp.precision) << std::fixed << fp.value;
+  return stream;
+}
 
 inline std::ostream& operator<<(std::ostream& stream, const Jmap& json){
   stream << '{';

--- a/valhalla/tyr/locate_handler.h
+++ b/valhalla/tyr/locate_handler.h
@@ -2,6 +2,8 @@
 #define VALHALLA_TYR_LOCATE_HANDLER_H_
 
 #include <valhalla/tyr/handler.h>
+#include <valhalla/sif/dynamiccost.h>
+#include <valhalla/baldr/graphreader.h>
 
 namespace valhalla{
 namespace tyr{
@@ -34,6 +36,9 @@ class LocateHandler : public Handler {
   virtual std::string Action();
 
  protected:
+  std::vector<baldr::Location> locations_;
+  valhalla::sif::cost_ptr_t cost_;
+  std::unique_ptr<valhalla::baldr::GraphReader> reader_;
 };
 
 }

--- a/valhalla/tyr/route_handler.h
+++ b/valhalla/tyr/route_handler.h
@@ -4,7 +4,6 @@
 #include <valhalla/tyr/handler.h>
 #include <valhalla/sif/dynamiccost.h>
 #include <valhalla/baldr/graphreader.h>
-#include <string>
 #include <memory>
 
 namespace valhalla{
@@ -40,6 +39,7 @@ class RouteHandler : public Handler {
   virtual std::string Action();
 
  protected:
+  std::vector<baldr::Location> locations_;
   valhalla::sif::cost_ptr_t cost_;
   std::unique_ptr<valhalla::baldr::GraphReader> reader_;
 };


### PR DESCRIPTION
@drewda @irees this will let you guys query a batch of locations against the route graph network. a sample request might look like:

    http://localhost:8002/locate?json={"locations":[{"lat":40.335725,"lon":-76.407814},{"lat":40.336244,"lon":-76.406006}],"costing":"pedestrian"}

A response will, for the time being, look something like this. Let us know what changes you might want to make here:

    [
        {
            "input_lon": -76.407814,
            "ways": [
                {
                    "correlated_lon": -76.407814,
                    "way_id": 12292929,
                    "correlated_lat": 40.335724
                }
            ],
            "input_lat": 40.335724
        },
        {
            "input_lon": -76.407814,
            "ways": [
                {
                    "correlated_lon": -76.407814,
                    "way_id": 12292929,
                    "correlated_lat": 40.335724
                }
            ],
            "input_lat": 40.335724
        }
    ]