### PR TITLE
small change for primeserver logging

### DIFF
--- a/src/tyr/service.cc
+++ b/src/tyr/service.cc
@@ -428,8 +428,8 @@ namespace {
     tyr_worker_t(const boost::property_tree::ptree& config):config(config) {
     }
     worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info) {
-      auto* info = static_cast<http_request_t::info_t*>(request_info);
-      LOG_INFO("Got Tyr Request " + std::to_string(info->id));
+      auto info = *static_cast<http_request_t::info_t*>(request_info);
+      LOG_INFO("Got Tyr Request " + std::to_string(info.id));
       try{
         //get some info about what we need to do
         std::string request_str(static_cast<const char*>(job.front().data()), job.front().size());

--- a/src/tyr/service.cc
+++ b/src/tyr/service.cc
@@ -428,7 +428,7 @@ namespace {
     tyr_worker_t(const boost::property_tree::ptree& config):config(config) {
     }
     worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info) {
-      auto info = *static_cast<http_request_t::info_t*>(request_info);
+      auto& info = *static_cast<http_request_t::info_t*>(request_info);
       LOG_INFO("Got Tyr Request " + std::to_string(info.id));
       try{
         //get some info about what we need to do


### PR DESCRIPTION
requires prime_server reinstall

request logging is much more readible and useful:

    0 2015/05/13 18:28:11.888755 GET /viaroute?costing=auto&instructions=true&loc=40.346282459755756%2C-76.68354034423828&loc=40.34333869878784%2C-76.65658950805664&jsonp=_l_geocoder_0 HTTP/1.1
    2015/05/13 18:28:11.888901 [INFO] Got Loki Request 0
    2015/05/13 18:28:11.913714 [INFO] Got Thor Request 0
    2015/05/13 18:28:11.917698 [INFO] PathCost = 438.244934  Iterations = 1020
    2015/05/13 18:28:11.918082 [INFO] Got Odin Request 0
    2015/05/13 18:28:11.918203 [INFO] trip_path_->node_size()=9
    2015/05/13 18:28:11.918408 [INFO] Got Tyr Request 0
    0 2015/05/13 18:28:11.918661 200 982

first and last lines are request and reply respectively. the response line is request_id date time response_code size_in_bytes.
