### PR TITLE
Added roundabout_exit_count to roundabout maneuvers

### DIFF
--- a/src/tyr/service.cc
+++ b/src/tyr/service.cc
@@ -540,6 +540,11 @@ namespace {
             man->emplace("sign", std::move(sign));
           }
 
+          // Roundabout count
+          if (maneuver.has_roundabout_exit_count()) {
+            man->emplace("roundabout_exit_count", static_cast<uint64_t>(maneuver.roundabout_exit_count()));
+          }
+
           //  man->emplace("hasGate", maneuver.);
           //  man->emplace("hasFerry", maneuver.);
           //“portionsTollNote” : “<portionsTollNote>”,


### PR DESCRIPTION
this will close #81 

{
    "roundabout_exit_count": 3,
    "begin_shape_index": 1,
    "street_names": 
    [
        "East Wheel Road"
    ],
    "time": 27,
    "type": 26,
    "end_shape_index": 23,
    "instruction": "Enter the roundabout and take the 3rd exit.",
    "length": 0.041,
    "verbal_transition_alert_instruction": "Enter roundabout.",
    "verbal_pre_transition_instruction": "Enter the roundabout and take the 3rd exit."
},