### PR TITLE
serializing requests as json instead of ptree now

### DIFF
--- a/src/tyr/service.cc
+++ b/src/tyr/service.cc
@@ -7,7 +7,6 @@
 #include <sstream>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/info_parser.hpp>
 
 #include <prime_server/prime_server.hpp>
 #include <prime_server/http_protocol.hpp>
@@ -732,7 +731,7 @@ namespace {
         boost::property_tree::ptree request;
 
         try{
-          boost::property_tree::read_info(stream, request);
+          boost::property_tree::read_json(stream, request);
         }
         catch(...) {
           worker_t::result_t result{false};


### PR DESCRIPTION
sample request:
http://localhost:8002/route?json={%22locations%22:[{%22lat%22:40.85738,%22lon%22:-73.867653,%22type%22:%22break%22,%22street%22:%22White%20Plains%20Road%22},{%22lat%22:40.67646,%22lon%22:-73.982643,%22type%22:%22break%22,%22street%22:%22President%20Street%22}],%22costing%22:%22multimodal%22,%22date_time%22:{%22type%22:0}}&api_key=